### PR TITLE
fix installation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 ### Fixed
 - Fixed spelling in the installation script ([#2](https://github.com/egel/tmux-gruvbox/issues/2))
-- Fixed visual bugs in gruvbox dark theme after release ofi new tmux v2.9 ([#6](https://github.com/egel/tmux-gruvbox/issues/6))
+- Fixed visual bugs in gruvbox dark theme after release of new tmux v2.9 ([#6](https://github.com/egel/tmux-gruvbox/issues/6))
+- Fixed installation script by removing the no longer used `attr` from dark and light themes ([#15](https://github.com/egel/tmux-gruvbox/issues/15))
 
 ### Security
 

--- a/gruvbox-tpm.tmux
+++ b/gruvbox-tpm.tmux
@@ -10,9 +10,9 @@ get_theme() {
 	local option_value
   option_value=$(tmux show-option -gqv "$option")
 	if [ -z "$option_value" ]; then
-		print "$default_value"
+		echo "$default_value"
 	else
-		print "$option_value"
+		echo "$option_value"
 	fi
 }
 

--- a/tmux-gruvbox-dark.conf
+++ b/tmux-gruvbox-dark.conf
@@ -35,7 +35,7 @@ set-window-option -g window-status-bell-style bg=colour167,fg=colour235 # bg=red
 
 ## Theme settings mixed with colors (unfortunately, but there is no cleaner way)
 set-option -g status-justify "left"
-set-option -g status-left-style attr="none"
+set-option -g status-left-style none
 set-option -g status-left-length "80"
 set-option -g status-right-style none
 set-option -g status-right-length "80"

--- a/tmux-gruvbox-light.conf
+++ b/tmux-gruvbox-light.conf
@@ -41,9 +41,9 @@ set-window-option -g window-status-bell-style bg=colour124,fg=colour229 # bg=red
 
 ## Theme settings mixed with colors (unfortunately, but there is no cleaner way)
 set-option -g status-justify "left"
-set-option -g status-left-style attr="none"
+set-option -g status-left-style none
 set-option -g status-left-length "80"
-set-option -g status-right-style attr="none"
+set-option -g status-right-style none
 set-option -g status-right-length "80"
 set-window-option -g window-status-separator ""
 


### PR DESCRIPTION
After the commit 9cb521fef1cb6a0e72e9ae838c655fc06f603251, every time i open tmux, this message is shown:

```
.tmux/plugins/tmux-gruvbox/tmux-gruvbox-dark.conf:38: bad style: attr=none
```

with the new light theme:

```
.tmux/plugins/tmux-gruvbox/tmux-gruvbox-light.conf:44: bad style: attr=none
.tmux/plugins/tmux-gruvbox/tmux-gruvbox-light.conf:46: bad style: attr=none
```

This fix the #15 