### PR TITLE
Use window status style in window status format

### DIFF
--- a/tmux-gruvbox-dark.conf
+++ b/tmux-gruvbox-dark.conf
@@ -5,13 +5,13 @@ set-option -g status "on"
 set-option -g status-style bg=colour237,fg=colour223 # bg=bg1, fg=fg1
 
 # default window title colors
-set-window-option -g window-status-style bg=colour214,fg=colour237 # bg=yellow, fg=bg1
+set-window-option -g window-status-style bg=colour239,fg=colour223 # bg=bg2, fg=bg1
 
 # default window with an activity alert
 set-window-option -g window-status-activity-style bg=colour237,fg=colour248 # bg=bg1, fg=fg3
 
 # active window title colors
-set-window-option -g window-status-current-style bg=red,fg=colour237 # fg=bg1
+set-window-option -g window-status-current-style bg=colour214,fg=colour239 # bg=yellow, fg=bg2
 
 # pane border
 set-option -g pane-active-border-style fg=colour250 #fg2
@@ -44,7 +44,7 @@ set-window-option -g window-status-separator ""
 set-option -g status-left "#[bg=colour241,fg=colour248] #S #[bg=colour237,fg=colour241,nobold,noitalics,nounderscore]"
 set-option -g status-right "#[bg=colour237,fg=colour239 nobold, nounderscore, noitalics]#[bg=colour239,fg=colour246] %Y-%m-%d  %H:%M #[bg=colour239,fg=colour248,nobold,noitalics,nounderscore]#[bg=colour248,fg=colour237] #h "
 
-set-window-option -g window-status-current-format "#[bg=colour214,fg=colour237,nobold,noitalics,nounderscore]#[bg=colour214,fg=colour239] #I #[bg=colour214,fg=colour239,bold] #W#{?window_zoomed_flag,*Z,} #[bg=colour237,fg=colour214,nobold,noitalics,nounderscore]"
-set-window-option -g window-status-format "#[bg=colour239,fg=colour237,noitalics]#[bg=colour239,fg=colour223] #I #[bg=colour239,fg=colour223] #W #[bg=colour237,fg=colour239,noitalics]"
+set-window-option -g window-status-current-format "#[fg=colour237,nobold,noitalics,nounderscore]#[fg=default] #I #[bold] #W#{?window_zoomed_flag,*Z,} #[fg=colour237,reverse,nobold,noitalics,nounderscore]"
+set-window-option -g window-status-format "#[fg=colour237,noitalics]#[fg=default] #I  #W #[fg=colour237,reverse,noitalics]"
 
 # vim: set ft=tmux tw=0 nowrap:

--- a/tmux-gruvbox-light.conf
+++ b/tmux-gruvbox-light.conf
@@ -11,13 +11,13 @@ set-option -g status "on"
 set-option -g status-style bg=colour252,fg=colour239 # bg=notInGruvboxPallete, #fg=fg1
 
 # default window title colors
-set-window-option -g window-status-style bg=colour66,fg=colour229 # bg=aqua, fg=bg5
+set-window-option -g window-status-style bg=colour249,fg=colour241 # bg=notInGruvboxPallete, fg=notInGruvboxPallete
 
 # default window with an activity alert
 set-window-option -g window-status-activity-style bg=colour237,fg=colour241 # bg=bg1, fg=notInGruvboxPallete
 
 # active window title colors
-set-window-option -g window-status-current-style bg=default,fg=colour237 # bg=default, fg=bg1
+set-window-option -g window-status-current-style bg=colour215,fg=colour239 # bg=notInGruvboxPallete, fg=fg1
 
 # pane border
 set-option -g pane-active-border-style fg=colour241 # fg=notInGruvboxPallete
@@ -50,7 +50,7 @@ set-window-option -g window-status-separator ""
 set-option -g status-left "#[bg=colour243,fg=colour255] #S #[bg=colour252,fg=colour243,nobold,noitalics,nounderscore]"
 set-option -g status-right "#[bg=colour252,fg=colour243,nobold,nounderscore,noitalics]#[bg=colour243,fg=colour255] %Y-%m-%d  %H:%M #[bg=colour243,fg=colour237,nobold,noitalics,nounderscore]#[bg=colour237,fg=colour255] #h "
 
-set-window-option -g window-status-current-format "#[bg=colour215,fg=colour252,nobold,noitalics,nounderscore]#[bg=colour215,fg=colour239] #I #[bg=colour215,fg=colour239,bold] #W#{?window_zoomed_flag,*Z,} #[bg=colour252,fg=colour215,nobold,noitalics,nounderscore]"
-set-window-option -g window-status-format "#[bg=colour249,fg=colour252,noitalics]#[bg=colour249,fg=colour241] #I #[bg=colour249,fg=colour241] #W #[bg=colour252,fg=colour249,noitalics]"
+set-window-option -g window-status-current-format "#[fg=colour252,nobold,noitalics,nounderscore]#[fg=default] #I #[bold] #W#{?window_zoomed_flag,*Z,} #[fg=colour252,reverse,nobold,noitalics,nounderscore]"
+set-window-option -g window-status-format "#[fg=colour252,noitalics]#[fg=default] #I  #W #[fg=colour252,reverse,noitalics]"
 
 # vim: set ft=tmux tw=0 nowrap:


### PR DESCRIPTION
Avoid overriding the colours defined in the style
in the format. This fixes bug #12.