### PR TITLE
Fix typo

### DIFF
--- a/src/gruvbox-main.sh
+++ b/src/gruvbox-main.sh
@@ -4,7 +4,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly CURRENT_DIR
 
 # hold the array of all command to configure tmux theme
-declate -a TMUX_CMDS
+declare -a TMUX_CMDS
 
 # load libraries
 # shellcheck disable=1091


### PR DESCRIPTION
This should probably say `declare` instead of `declate` to create an array.

I ran into this as I tried your theme for the first time and it always failed.
So this is kind of a big bug for first time users or folks who pull an update