### PR TITLE
Improve usability by adding visual indicators through the use of colors

### DIFF
--- a/src/gruvbox-main.sh
+++ b/src/gruvbox-main.sh
@@ -23,7 +23,7 @@ readonly TMUX_GRUVBOX_RIGHT_STAUTS_Z="@tmux-gruvbox-right-status-z"
 readonly DEFAULT_THEME="dark256"
 readonly DEFAULT_STATUSBAR_ALPHA='false'
 # defaults for theme option (with color interpolation)
-readonly DEFAULT_LEFT_STATUS_A='#S hehe haha'
+readonly DEFAULT_LEFT_STATUS_A='#S Test#1'
 readonly DEFAULT_RIGHT_STATUS_X='%Y-%m-%d'
 readonly DEFAULT_RIGHT_STATUS_Y='%H:%M'
 readonly DEFAULT_RIGHT_STATUS_Z='#h'

--- a/src/gruvbox-main.sh
+++ b/src/gruvbox-main.sh
@@ -23,7 +23,7 @@ readonly TMUX_GRUVBOX_RIGHT_STAUTS_Z="@tmux-gruvbox-right-status-z"
 readonly DEFAULT_THEME="dark256"
 readonly DEFAULT_STATUSBAR_ALPHA='false'
 # defaults for theme option (with color interpolation)
-readonly DEFAULT_LEFT_STATUS_A='#S'
+readonly DEFAULT_LEFT_STATUS_A='#S hehe haha'
 readonly DEFAULT_RIGHT_STATUS_X='%Y-%m-%d'
 readonly DEFAULT_RIGHT_STATUS_Y='%H:%M'
 readonly DEFAULT_RIGHT_STATUS_Z='#h'

--- a/src/gruvbox-main.sh
+++ b/src/gruvbox-main.sh
@@ -23,7 +23,7 @@ readonly TMUX_GRUVBOX_RIGHT_STAUTS_Z="@tmux-gruvbox-right-status-z"
 readonly DEFAULT_THEME="dark256"
 readonly DEFAULT_STATUSBAR_ALPHA='false'
 # defaults for theme option (with color interpolation)
-readonly DEFAULT_LEFT_STATUS_A='#S Test#1'
+readonly DEFAULT_LEFT_STATUS_A='#S'
 readonly DEFAULT_RIGHT_STATUS_X='%Y-%m-%d'
 readonly DEFAULT_RIGHT_STATUS_Y='%H:%M'
 readonly DEFAULT_RIGHT_STATUS_Z='#h'

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1}],fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]} ${_left_status_a} #[bg=${col_bg1}],fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -70,10 +70,10 @@ theme_set_dark() {
   # current window
   local _current_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _current_window_status_format_bg="default"; fi
-  tmux_append_setwo "window-status-current-format" "#[bg=${col_yellow2},fg=${col_bg1},nobold,noitalics,nounderscore]#[bg=${col_yellow2},fg=${col_bg2}] #I #[bg=${col_yellow2},fg=${col_bg2},bold] #W#{?window_zoomed_flag,*Z,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_yellow2},nobold,noitalics,nounderscore]"
+  tmux_append_setwo "window-status-current-format" "#[bg=${col_yellow2},fg=${col_bg1},nobold,noitalics,nounderscore]#[bg=${col_yellow2},fg=${col_bg2}] #I #[bg=${col_yellow2},fg=${col_bg2},bold] #W#{?window_zoomed_flag,*Z,} #{?window_marked_flag,*M ,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_yellow2},nobold,noitalics,nounderscore]"
 
   # default window
   local _default_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _default_window_status_format_bg="default"; fi
-  tmux_append_setwo "window-status-format" "#[bg=${col_bg2},fg=${col_bg1},noitalics]#[bg=${col_bg2},fg=${col_fg1}] #I #[bg=${col_bg2},fg=${col_fg1}] #W #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_bg2},noitalics]"
+  tmux_append_setwo "window-status-format" "#[bg=${col_bg2},fg=${col_bg1},noitalics]#[bg=${col_bg2},fg=${col_fg1}] #I #[bg=${col_bg2},fg=${col_fg1}] #W #{?window_marked_flag,*M ,} #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_bg2},noitalics]"
 }

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #{?client_prefix,[bg=${col_red2}],[bg=${col_bg1}]},fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg1}]},fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -70,7 +70,7 @@ theme_set_dark() {
   # current window
   local _current_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _current_window_status_format_bg="default"; fi
-  tmux_append_setwo "window-status-current-format" "#[bg=${col_yellow2},fg=${col_bg1},nobold,noitalics,nounderscore]#[bg=${col_yellow2},fg=${col_bg2}] #I #[bg=${col_yellow2},fg=${col_bg2},bold] #W#{?window_zoomed_flag,*Z,} #{?window_marked_flag,*M ,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_yellow2},nobold,noitalics,nounderscore]"
+  tmux_append_setwo "window-status-current-format" "#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_yellow2}]}#[fg=${col_bg1},nobold,noitalics,nounderscore]#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_yellow2}]}#[fg=${col_bg2}] #I #{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_yellow2}]}#[fg=${col_bg2},bold] #W#{?window_zoomed_flag,*Z,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg1}]}#{?window_marked_flag,#[fg=${col_red2}],#[fg=${col_yellow2}]}#[nobold,noitalics,nounderscore]"
 
   # default window
   local _default_window_status_format_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${red}],} #[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],} #[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg1}]},fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1}],fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]}#[fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1}]#{?client_prefix,#[fg=${col_red2}],#[fg=${col_bg3}]}#[nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_orange2}],#[bg=${col_bg3}]}#[fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1}]#{?client_prefix,#[fg=${col_orange2}],#[fg=${col_bg3}]}#[nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}
@@ -70,10 +70,10 @@ theme_set_dark() {
   # current window
   local _current_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _current_window_status_format_bg="default"; fi
-  tmux_append_setwo "window-status-current-format" "#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_yellow2}]}#[fg=${col_bg1},nobold,noitalics,nounderscore]#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_yellow2}]}#[fg=${col_bg2}] #I #{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_yellow2}]}#[fg=${col_bg2},bold] #W#{?window_zoomed_flag,*Z,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg1}]}#{?window_marked_flag,#[fg=${col_red2}],#[fg=${col_yellow2}]}#[nobold,noitalics,nounderscore]"
+  tmux_append_setwo "window-status-current-format" "#{?window_marked_flag,#[bg=${col_orange2}],#[bg=${col_yellow2}]}#[fg=${col_bg1},nobold,noitalics,nounderscore]#{?window_marked_flag,#[bg=${col_orange2}],#[bg=${col_yellow2}]}#[fg=${col_bg2}] #I #{?window_marked_flag,#[bg=${col_orange2}],#[bg=${col_yellow2}]}#[fg=${col_bg2},bold] #W#{?window_zoomed_flag,*Z,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg1}]}#{?window_marked_flag,#[fg=${col_orange2}],#[fg=${col_yellow2}]}#[nobold,noitalics,nounderscore]"
 
   # default window
   local _default_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _default_window_status_format_bg="default"; fi
-  tmux_append_setwo "window-status-format" "#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_bg2}]}#[fg=${col_bg1},noitalics]#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_bg2}]}#[fg=${col_fg1}] #I #{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_bg2}]}#[fg=${col_fg1}] #W #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg1}]}#{?window_marked_flag,#[fg=${col_red2}],#[fg=${col_bg2}]}#[noitalics]"
+  tmux_append_setwo "window-status-format" "#{?window_marked_flag,#[bg=${col_orange2}],#[bg=${col_bg2}]}#[fg=${col_bg1},noitalics]#{?window_marked_flag,#[bg=${col_orange2}],#[bg=${col_bg2}]}#[fg=${col_fg1}] #I #{?window_marked_flag,#[bg=${col_orange2}],#[bg=${col_bg2}]}#[fg=${col_fg1}] #W #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg1}]}#{?window_marked_flag,#[fg=${col_orange2}],#[fg=${col_bg2}]}#[noitalics]"
 }

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -75,5 +75,5 @@ theme_set_dark() {
   # default window
   local _default_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _default_window_status_format_bg="default"; fi
-  tmux_append_setwo "window-status-format" "#[bg=${col_bg2},fg=${col_bg1},noitalics]#[bg=${col_bg2},fg=${col_fg1}] #I #[bg=${col_bg2},fg=${col_fg1}] #W #{?window_marked_flag,*M ,} #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_bg2},noitalics]"
+  tmux_append_setwo "window-status-format" "#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_bg2}]}#[fg=${col_bg1},noitalics]#{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_bg2}]}#[fg=${col_fg1}] #I #{?window_marked_flag,#[bg=${col_red2}],#[bg=${col_bg2}]}#[fg=${col_fg1}] #W #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg1}]}#{?window_marked_flag,#[fg=${col_red2}],#[fg=${col_bg2}]}#[noitalics]"
 }

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${red}],} #[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]} ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]}#[fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1}]#{?client_prefix,#[fg=${col_red2}],#[fg=${col_bg3}]}#[nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]} ${_left_status_a} #[bg=${col_bg1}],fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],#[bg=${col_bg3}]} ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_dark.sh
+++ b/src/theme_gruvbox_dark.sh
@@ -60,7 +60,7 @@ theme_set_dark() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
-  tmux_append_seto "status-left" "#{?client_prefix,#[bg=${col_red2}],} #[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
+  tmux_append_seto "status-left" "#[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #{?client_prefix,[bg=${col_red2}],[bg=${col_bg1}]},fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
   local _status_right_bg=${col_bg1}

--- a/src/theme_gruvbox_light.sh
+++ b/src/theme_gruvbox_light.sh
@@ -60,6 +60,7 @@ theme_set_light() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
+  # TODO: Add indicator for client_prefix like dark theme
   tmux_append_seto "status-left" "#[bg=${col_bg3},fg=${col_fg3}] ${_left_status_a} #[bg=${col_bg1},fg=${col_bg3},nobold,noitalics,nounderscore]"
 
   # right status
@@ -70,10 +71,12 @@ theme_set_light() {
   # current window
   local _current_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _current_window_status_format_bg="default"; fi
+  # TODO: Add indicator for window_marked_flag like dark theme
   tmux_append_setwo "window-status-current-format" "#[bg=${col_yellow2},fg=${col_bg1},nobold,noitalics,nounderscore]#[bg=${col_yellow2},fg=${col_bg2}] #I #[bg=${col_yellow2},fg=${col_bg2},bold] #W#{?window_zoomed_flag,*Z,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_yellow2},nobold,noitalics,nounderscore]"
 
   # default window
   local _default_window_status_format_bg=${col_bg1}
   if [[ "$_statusbar_alpha" == "true" ]]; then _default_window_status_format_bg="default"; fi
+  # TODO: Add indicator for window_marked_flag like dark theme
   tmux_append_setwo "window-status-format" "#[bg=${col_bg2},fg=${col_bg1},noitalics]#[bg=${col_bg2},fg=${col_fg1}] #I #[bg=${col_bg2},fg=${col_fg1}] #W #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg1}]}#[fg=${col_bg2},noitalics]"
 }

--- a/src/theme_gruvbox_light256.sh
+++ b/src/theme_gruvbox_light256.sh
@@ -60,6 +60,7 @@ theme_set_light256() {
   tmux_append_seto "status-right-length" "80"
   tmux_append_setwo "window-status-separator" ""
 
+  # TODO: Add indicator for client_prefix like dark theme
   tmux_append_seto "status-left" "#[bg=${col_fg2},fg=${col_bg1}] ${_left_status_a} #[bg=${col_bg2},fg=${col_fg2},nobold,noitalics,nounderscore]"
 
   # right status
@@ -70,10 +71,12 @@ theme_set_light256() {
   # current window
   local _current_window_status_format_bg=${col_bg2}
   if [[ "$_statusbar_alpha" == "true" ]]; then _current_window_status_format_bg="default"; fi
+  # TODO: Add indicator for window_marked_flag like dark theme
   tmux_append_setwo "window-status-current-format" "#[bg=${col_yellow},fg=${col_bg2},nobold,noitalics,nounderscore]#[bg=${col_yellow},fg=${col_fg1}] #I #[bg=${col_yellow},fg=${col_fg1},bold] #W#{?window_zoomed_flag,*Z,} #{?window_end_flag,#[bg=${_current_window_status_format_bg}],#[bg=${col_bg2}]}#[fg=${col_yellow},nobold,noitalics,nounderscore]"
 
   # default window
   local _default_window_status_format_bg=${col_bg2}
   if [[ "$_statusbar_alpha" == "true" ]]; then _default_window_status_format_bg="default"; fi
+  # TODO: Add indicator for window_marked_flag like dark theme
   tmux_append_setwo "window-status-format" "#[bg=${col_bg3},fg=${col_bg2},noitalics]#[bg=${col_bg3},fg=${col_fg2}] #I #[bg=${col_bg3},fg=${col_fg2}] #W #{?window_end_flag,#[bg=${_default_window_status_format_bg}],#[bg=${col_bg2}]}#[fg=${col_bg3},noitalics]"
 }


### PR DESCRIPTION
# Context
Wanted to make it more visually clear for when
- Prefix key has been pressed
- A pane inside a window has been marked

# What Changed
- Modified `status-left` to "light up" when prefixed has been pressed
- Modified `window-status-current-format` and `window-status-format` to indicate marked pane